### PR TITLE
Add instructions to run the yellowdemo instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,31 @@ This demo server just prints to the terminal when the invoice status changes - a
 Code comments contain additional documentation. For any other questions please email info@yellowpay.co
 
 Thanks for using Yellow!
+
+Setup Instructions
+==================
+
+* Create a python virtual environment and activate it
+* Install [ngrok](https://ngrok.com) and run it, point it at local port 8080. Make note of the URL ngrok gives you.
+* Within the root directory of yellowdemo, type:
+```
+pip install -r requirements.txt
+```
+* Source the basic environment setup script:
+```
+source env.sh
+```
+* Set up the following environment variables:
+```
+# Set this to the YellowServer supplied to you by the Yellow team
+export YELLOW_SERVER=yolanda-perkins.heroku.com
+# Set this to the ngrok URL from above
+export ROOT_URL=https://dummy.ngrok.com
+# Set this to the yellow API Key and Secret given to you by the Yellow team
+export YELLOW_KEY=XXX
+export YELLOW_SECRET=XXX
+```
+* Run the server!
+```
+python manage.py runserver 127.0.0.1:8080
+```

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export DEBUG=1
+export DJANGO_PROJECT=yellowdemo
+# This is a dummy SECRET_KEY provided for convenience, make sure you change if you
+# ever run this on a public facing website
+export SECRET_KEY=375e64bf082645951ba9fc1ced1e3f4f


### PR DESCRIPTION
Geared for customers, devs don't need ngrok, but its easy to deduct that.
